### PR TITLE
WordPress Daily Prayer Time Integration

### DIFF
--- a/islamic_prayer_times_ie/README.md
+++ b/islamic_prayer_times_ie/README.md
@@ -1,4 +1,7 @@
-# Hass.io Custom Component - Islamic Prayer Times -IE
+# Hass.io Custom Component - Islamic Prayer Times -IE (Deprecated)
+
+NOTE: This is a deprecated custom component, it is replaced by the wordpress_daily_prayer_time.
+
 This custom component is a forklift of the built-in Home Assistant Islamic Prayer Times component,
 but includes prayers times calculated by [Islamic Cultural Centre of Ireland: ICCI](https://islamireland.ie/)
 along with other calculation methods ignored in the built-in one such as Egypt, France ...etc.
@@ -20,4 +23,4 @@ along with other calculation methods ignored in the built-in one such as Egypt, 
 * Modified by [modestpharaoh](https://github.com/modestpharaoh)
 
 ## Disclamation
-* There is guarantee that the component will get the correct one, I always try my best to update, whenever there is a bug show up. 
+* There is no guarantee that the component will get the correct one, I always try my best to update, whenever there is a bug show up. 

--- a/wordpress_daily_prayer_time/README.md
+++ b/wordpress_daily_prayer_time/README.md
@@ -1,0 +1,47 @@
+# WordPress Daily Prayer Time Integration
+
+This is a custom Home Assistant integration for fetching and displaying daily prayer times from a WordPress-based website with [Daily Prayer Time - Plugin](https://wordpress.org/plugins/daily-prayer-time-for-mosques/)
+
+## Features
+
+- Fetches daily prayer times from a WordPress - Daily Prayer Time - API.
+- Displays prayer times in Home Assistant.
+- Supports automation refresh everyday after midnight.
+- Support fetching the full year by default and save it to Home Assistant config directory. In case you site wasn't reachable by the time of the update, it will fallback to the saved prayer of the year.
+
+## Installation
+
+1. Clone this repository into your Home Assistant.
+2. Move the `wordpress_daily_prayer_time` directory to Home Assistant `custom_components` directory. 
+3. Ensure the directory structure is as follows:
+  ```
+  custom_components/
+  └── wordpress_daily_prayer_time/
+     ├── __init__.py
+     ├── manifest.json
+     ├── sensor.py
+     └── ...
+  ```
+4. Restart Home Assistant.
+
+## Configuration
+
+1. Open `Device & Services` Dashboard.
+2. ADD INTEGRATION: `WordPress Daily Prayer Time`, and fill the following parameters:
+
+   a. `Endpoint URL`: Enter a valid http/https masjid Wordpress site. e.g. `https://masjid-wp.com`
+
+   b. `API Path`: API path for full year, default `wp-json/dpt/v1/prayertime?filter=year`
+
+
+## Usage
+
+Once configured, the integration will create sensors for each prayer Athan/Iqamah. You can use these sensors in your automations or display them in your dashboard.
+
+## Troubleshooting
+
+- Ensure the API URL is correct and accessible.
+- Check the Home Assistant logs for any errors.
+
+## Disclamation
+* There is no guarantee that the component will get the correct one, I always try my best to update, whenever there is a bug show up. 

--- a/wordpress_daily_prayer_time/__init__.py
+++ b/wordpress_daily_prayer_time/__init__.py
@@ -1,0 +1,81 @@
+"""WordPress Daily Prayer Time integration for Home Assistant."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+from .coordinator import (
+    PrayerTimeCoordinator,
+    WordpressPrayerTimeConfigEntry,
+)
+from .const import CONF_ENDPOINT, CONF_API_PATH
+
+PLATFORMS = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WordpressPrayerTimeConfigEntry,
+) -> bool:
+    """Set up WordPress Daily Prayer Time from a config entry."""
+
+    @callback
+    def update_unique_id(
+        entity_entry: er.RegistryEntry,
+    ) -> dict[str, str] | None:
+        """Update unique ID of entity entry."""
+        if not entity_entry.unique_id.startswith(f"{entry.entry_id}-"):
+            new_unique_id = f"{entry.entry_id}-{entity_entry.unique_id}"
+            return {"new_unique_id": new_unique_id}
+        return None
+
+    _LOGGER.debug("Setting up WordPress Daily Prayer Time with entry: %s", entry)
+    endpoint: str = entry.options[CONF_ENDPOINT]
+    api_path: str = entry.options[CONF_API_PATH]
+    
+    await er.async_migrate_entries(hass, entry.entry_id, update_unique_id)
+
+    coordinator = PrayerTimeCoordinator(
+        hass,
+        config_entry=entry,
+        endpoint=endpoint,
+        api_path=api_path,
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+    entry.async_on_unload(
+        entry.add_update_listener(async_options_updated)
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+async def async_unload_entry(
+    hass: HomeAssistant,
+    entry: WordpressPrayerTimeConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(
+        entry, PLATFORMS
+    ):
+        coordinator = entry.runtime_data
+        if coordinator.event_unsub:
+            coordinator.event_unsub()
+    return unload_ok
+
+async def async_options_updated(
+    hass: HomeAssistant,
+    entry: WordpressPrayerTimeConfigEntry,
+) -> None:
+    """Handle an options update."""
+    coordinator = entry.runtime_data
+    if coordinator.event_unsub:
+        coordinator.event_unsub()
+    await coordinator.async_request_refresh()

--- a/wordpress_daily_prayer_time/config_flow.py
+++ b/wordpress_daily_prayer_time/config_flow.py
@@ -1,0 +1,114 @@
+"""Config flow for WordPress Daily Prayer Time integration."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import voluptuous as vol
+
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    TextSelector,
+)
+
+from .const import CONF_ENDPOINT, CONF_API_PATH, DEFAULT_API_PATH, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+class PrayerTimeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for WordPress Daily Prayer Time."""
+
+    VERSION = 1
+
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            _LOGGER.debug("Entering async_step_user with user_input is None")
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_ENDPOINT,
+                        ): TextSelector(),
+                        vol.Required(
+                            CONF_API_PATH,
+                            default=DEFAULT_API_PATH,
+                        ): TextSelector(),
+                    }
+                ),
+                errors={"endpoint": "invalid_url"},
+            )
+
+        endpoint = user_input[CONF_ENDPOINT]
+        _LOGGER.debug("Validating endpoint: %s", endpoint)
+        endpoint_regex = r"^(https?://)([a-zA-Z0-9.-]+)(:\d+)?(/.*)?$"
+        if not re.match(endpoint_regex, endpoint):
+            _LOGGER.error("Invalid URL format: %s", endpoint)
+            return self.async_abort(reason="invalid_url")
+        _LOGGER.debug("Endpoint is valid: %s", endpoint)
+
+        endpoint = user_input[CONF_ENDPOINT]
+        parsed_url = urlparse(endpoint)
+        website = parsed_url.netloc.split(":")[0]  # Remove port if present
+        _LOGGER.debug("Naming the entry with website: %s", website)
+
+        self._async_abort_entries_match(
+            {
+                CONF_ENDPOINT: user_input[CONF_ENDPOINT],
+                CONF_API_PATH: user_input[CONF_API_PATH],
+            },
+        )
+        return self.async_create_entry(
+            title=website,
+            data={},
+            options={
+                **user_input,
+            },
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> OptionsFlow:
+        """Create the options flow."""
+        return OptionsFlowHandler()
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handle options flow for WordPress Daily Prayer Time."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_ENDPOINT,
+                        default=self.config_entry.options[CONF_ENDPOINT]
+                    ): TextSelector(),
+                    vol.Required(
+                        CONF_API_PATH,
+                        default=self.config_entry.options[CONF_API_PATH]
+                    ): TextSelector()
+                }
+            ),
+        )

--- a/wordpress_daily_prayer_time/const.py
+++ b/wordpress_daily_prayer_time/const.py
@@ -1,0 +1,32 @@
+"""Constants for the WordPress Daily Prayer Time integration."""
+
+from typing import Final
+
+
+DOMAIN: Final = "wordpress_daily_prayer_time"
+NAME: Final = "WordPress Daily Prayer Time"
+
+# Sensor keys for prayer times
+PRAYER_TIME_KEYS: Final = [
+    "fajr_begins",
+    "fajr_jamah",
+    "sunrise",
+    "zuhr_begins",
+    "zuhr_jamah",
+    "asr_mithl_1",
+    "asr_jamah",
+    "maghrib_begins",
+    "maghrib_jamah",
+    "isha_begins",
+    "isha_jamah",
+]
+
+CONF_ENDPOINT: Final = "endpoint"
+CONF_API_PATH: Final = "api_path"
+DEFAULT_API_PATH: Final = "wp-json/dpt/v1/prayertime?filter=year"
+
+# Additional sensor key for Hijri date
+HIJRI_DATE_KEY: Final = "hijri_date"
+
+# Timeout for querying the endpoint
+QUERY_TIMEOUT = 10  # seconds

--- a/wordpress_daily_prayer_time/coordinator.py
+++ b/wordpress_daily_prayer_time/coordinator.py
@@ -1,0 +1,212 @@
+"""Data coordinator for WordPress Daily Prayer Time integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import json
+import logging
+import os
+import random
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+
+import aiohttp
+import aiofiles
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_ENDPOINT, CONF_API_PATH, DEFAULT_API_PATH, DOMAIN, QUERY_TIMEOUT
+
+_LOGGER = logging.getLogger(__name__)
+
+type WordpressPrayerTimeConfigEntry = ConfigEntry[PrayerTimeCoordinator]
+
+
+class PrayerTimeCoordinator(DataUpdateCoordinator):
+    """Coordinator to manage prayer time data fetching."""
+
+    config_entry: WordpressPrayerTimeConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: WordpressPrayerTimeConfigEntry,
+        endpoint: str,
+        api_path: str = DEFAULT_API_PATH,
+    ) -> None:
+        """Initialize the coordinator."""
+        # Remove trailing slashes from the endpoint
+        endpoint = endpoint.rstrip("/")
+        self.fullendpoint = endpoint + '/' + api_path
+        self.hass = hass
+        # Extract main domain from endpoint
+        parsed_url = urlparse(endpoint)
+        self.website = parsed_url.netloc.split(":")[0]  # Remove port if present
+        
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+        )
+
+    @property
+    def endpoint(self) -> str:
+        """Return the endpoint."""
+        return self.config_entry.options.get(CONF_ENDPOINT)
+
+    @property
+    def website_name(self) -> str:
+        """Return the website name."""
+        return self.website
+
+    async def async_request_update(self, _: datetime) -> None:
+        """Request update from coordinator."""
+        await self.async_request_refresh()
+
+    async def _async_update_data(self) -> Dict[str, Any]:
+        """Fetch prayer time data from the endpoint or fallback to saved file."""
+        _LOGGER.debug(f"_async_update_data: Fetching prayer time data from endpoint: {self.fullendpoint}")
+        session = async_get_clientsession(self.hass)
+        timeout = aiohttp.ClientTimeout(total=QUERY_TIMEOUT)
+        raw_data: list = []
+        prayer_times_info: dict[str, Any] = {}
+        try:
+            async with session.get(self.fullendpoint, timeout=timeout) as response:
+                if response.status != 200:
+                    raise UpdateFailed(f"Error fetching data: {response.status}")
+                _LOGGER.debug(f"Fetched prayer time successfully: {response.status}")
+                raw_data = await response.json()
+                # Save the response to a file
+                await self._save_response_to_file(raw_data)
+        except Exception as err:
+            _LOGGER.warning(f"Failed to fetch data from endpoint: {err}")
+            # Attempt to load from saved file
+            raw_data = await self._load_from_saved_file()
+        try:
+            # Process the data to extract today's prayer times
+            prayer_times_info = self._process_data(raw_data)
+            _LOGGER.debug(f"Processed prayer times info: {prayer_times_info}")
+        except Exception as err:
+            _LOGGER.error(f"Failed to process data: {err}")
+            raise UpdateFailed(f"Failed to process data: {err}") from err
+        
+        if len(prayer_times_info) > 0:
+            _LOGGER.debug(f"Parsed prayer times info: {prayer_times_info}")
+            # prayer_times_info["hijri_date"] = "20 Shawwal 1446"
+            _LOGGER.debug(f"Parsed prayer times info: {prayer_times_info}")
+            random_time = self._random_time_after_midnight()
+            self.async_schedule_future_update(random_time)
+            
+            return prayer_times_info
+        _LOGGER.error(f"No prayer times found for today")
+        # schedule the next update in 30 minutes
+        update_time = datetime.now() + timedelta(minutes=30)
+        _LOGGER.debug(f"Scheduling next update in 30 minutes: {update_time}")
+        self.async_schedule_future_update(update_time)
+        return prayer_times_info
+
+    async def _save_response_to_file(self, data: list) -> None:
+        """_save_response_to_file: Save the JSON response to a file in the config directory."""
+        _LOGGER.debug(f"Saving response to file")
+        try:
+            filename = f"{self.website}-prayer_for_year.json"
+            file_path = os.path.join(self.hass.config.config_dir, filename)
+            
+            # Write JSON to file
+            async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
+                json_str = json.dumps(data, ensure_ascii=False, indent=2)
+                await f.write(json_str)
+
+            # with open(file_path, "w", encoding="utf-8") as f:
+            #     json.dump(data, f, ensure_ascii=False, indent=2)
+            _LOGGER.debug(f"Saved prayer time data to {file_path}")
+        except Exception as err:
+            _LOGGER.error(f"Failed to save prayer time data to file: {err}")
+
+    # async def _load_from_saved_file(self) -> Dict[str, Any]:
+    async def _load_from_saved_file(self) -> list:
+        """_load_from_saved_file: Load prayer time data from the saved file."""
+        _LOGGER.debug(f"Attempting to load saved prayer time data from file")
+        try:
+            # Extract main domain from endpoint
+            parsed_url = urlparse(self.fullendpoint)
+            main_domain = parsed_url.netloc.split(":")[0]  # Remove port if present
+            filename = f"{main_domain}-prayer_for_year.json"
+            file_path = os.path.join(self.hass.config.config_dir, filename)
+            
+            # Read JSON from file
+            if os.path.exists(file_path):
+                async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
+                    content = await f.read()
+                    data = json.loads(content)
+                # with open(file_path, "r", encoding="utf-8") as f:
+                #     data = json.load(f)
+                _LOGGER.debug(f"Loaded prayer time data from {file_path}")
+                return data
+            else:
+                raise UpdateFailed("No saved prayer time data available")
+        except Exception as err:
+            raise UpdateFailed(f"Failed to load saved prayer time data: {err}") from err
+
+    def _process_data(self, data: list) -> Dict[str, Any]:
+        """Process the prayer time data to extract today's times."""
+        _LOGGER.debug(f"_process_data: Processing data to extract today's prayer times")
+        today = datetime.now().strftime("%Y-%m-%d")
+        _LOGGER.debug(f"Looping through prayer for today: {today}")
+        prayer_times_info: dict[str, Any] = {}
+        # Check if data is in the expected format
+        if not isinstance(data, list) or len(data) == 0:
+            raise ValueError("Invalid data format: Expected a non-empty list")
+        # Check if the first element is a list
+        if not isinstance(data[0], list):
+            raise ValueError("Invalid data format: Expected a list of lists")
+        # Check if the first element of the first list is a dictionary
+        if not isinstance(data[0][0], dict):
+            raise ValueError("Invalid data format: Expected a list of dictionaries")
+        for day_data in data[0]:
+            if day_data["d_date"] == today:
+                _LOGGER.info(f"Parsed Prayer for today: {day_data}")
+                # return day_data
+                for key, value in day_data.items():
+                    if key in ["d_date"]:
+                        continue
+                    elif key == "hijri_date":
+                        prayer_times_info[key] = day_data[key]
+                        _LOGGER.debug(f"Parsed Hijri date: {day_data[key]}")
+                    elif prayer_time := dt_util.parse_time(value):
+                        _LOGGER.debug(f"Parsed prayer time: {key} = {prayer_time}")
+                        prayer_datetime = datetime.combine(datetime.now().date(), prayer_time)
+                        _LOGGER.debug(f"Parsed prayer time: {key} = {prayer_datetime}")
+                        prayer_datetime_utc = dt_util.as_utc(prayer_datetime)
+                        _LOGGER.debug(f"Converted prayer time to UTC: {key} = {prayer_datetime_utc}")
+                        prayer_times_info[key] = prayer_datetime_utc
+                    else:
+                        _LOGGER.warning(f"Skipping invalid prayer time: {key} = {day_data[key]}")
+        return prayer_times_info
+
+    def _random_time_after_midnight(self) -> datetime:
+        """Generate a random datetime between 12:00 AM and 1:00 AM tomorrow."""
+        _LOGGER.debug(f"_random_time_after_midnight: Generating random time after midnight")
+        tomorrow = datetime.now() + timedelta(days=1)
+        midnight = datetime.combine(tomorrow.date(), dt_util.parse_time("00:00:00"))
+        one_am = datetime.combine(tomorrow.date(), dt_util.parse_time("01:00:00"))
+        _LOGGER.debug(f"Midnight: {midnight}, One AM: {one_am}")
+        random_seconds = random.randint(0, 3600)  # Random seconds between 0 and 3600
+        random_time = midnight + timedelta(seconds=random_seconds)
+        _LOGGER.debug(f"Random time after midnight: {random_time}")
+        return random_time
+
+    @callback
+    def async_schedule_future_update(self, dt: datetime) -> None:
+        """Schedule future update for sensors."""
+        _LOGGER.debug(f"Scheduling next update for Islamic prayer times at {dt}")
+
+        self.event_unsub = async_track_point_in_time(
+            self.hass, self.async_request_update, dt
+        )

--- a/wordpress_daily_prayer_time/manifest.json
+++ b/wordpress_daily_prayer_time/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "wordpress_daily_prayer_time",
+  "name": "WordPress Daily Prayer Time",
+  "codeowners": ["@modestpharaoh"],
+  "config_flow": true,
+  "documentation": "https://github.com/modestpharaoh/hassio-custom-components/tree/main/wordpress_daily_prayer_time",
+  "iot_class": "cloud_polling",
+  "loggers": ["wordpress_daily_prayer_time"],
+  "requirements": ["aiohttp", "aiofiles"],
+  "version": "1.0.0"
+}

--- a/wordpress_daily_prayer_time/sensor.py
+++ b/wordpress_daily_prayer_time/sensor.py
@@ -1,0 +1,127 @@
+"""Sensor platform for WordPress Daily Prayer Time integration."""
+import logging
+from datetime import datetime
+from typing import Union
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, HIJRI_DATE_KEY
+from .coordinator import (
+    PrayerTimeCoordinator,
+    WordpressPrayerTimeConfigEntry,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="fajr_begins",
+        name="Fajr Prayer",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="fajr_jamah",
+        name="Fajr Iqamah",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="sunrise",
+        name="Sunrise",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="zuhr_begins",
+        name="Dhuhr Prayer",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="zuhr_jamah",
+        name="Dhuhr Iqamah",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="asr_mithl_1",
+        name="Asr Prayer",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="asr_jamah",
+        name="Asr Iqamah",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="maghrib_begins",
+        name="Maghrib Prayer",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="maghrib_jamah",
+        name="Maghrib Iqamah",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="isha_begins",
+        name="Isha Prayer",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="isha_jamah",
+        name="Isha Iqamah",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key=HIJRI_DATE_KEY,
+        name="Hijri Date",
+        device_class=None,
+    ),
+)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WordpressPrayerTimeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the sensor platform."""
+
+    coordinator = config_entry.runtime_data
+    _LOGGER.debug("Setting up sensor with coordinator: %s", coordinator)
+    async_add_entities(
+        PrayerTimeSensor(coordinator, description)
+        for description in SENSOR_TYPES
+    )
+
+
+class PrayerTimeSensor(
+    CoordinatorEntity[PrayerTimeCoordinator], SensorEntity
+):
+    """Representation of an Islamic prayer time sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PrayerTimeCoordinator,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the Wordpress Daily Prayer Time sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
+            name=coordinator.website_name,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def native_value(self) -> Union[datetime, str]:
+        """Return the state of the sensor."""
+        return self.coordinator.data[self.entity_description.key]

--- a/wordpress_daily_prayer_time/strings.json
+++ b/wordpress_daily_prayer_time/strings.json
@@ -1,0 +1,41 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up WordPress Daily Prayer Time",
+        "description": "Enter the endpoint URL for prayer time data.",
+        "data": {
+          "endpoint": "Endpoint URL",
+          "api_path": "API Path"
+        },
+        "data_description": {
+          "endpoint": "WordPress Masjid website. e.g., https://masjid-site.com",
+          "api_path": "API path for full year, usually wp-json/dpt/v1/prayertime?filter=year"
+        },
+        "errors": {
+          "invalid_url": "Invalid URL. Please provide a valid HTTP or HTTPS URL."
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "WordPress Daily Prayer Time is already configured for this endpoint."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "endpoint": "Endpoint URL",
+          "api_path": "API Path"
+        },
+        "data_description": {
+          "endpoint": "WordPress Masjid website. e.g., https://masjid-site.com",
+          "api_path": "API path for full year, usually wp-json/dpt/v1/prayertime?filter=year"
+        },
+        "errors": {
+          "invalid_url": "Invalid URL. Please provide a valid HTTP or HTTPS URL."
+        }
+      }
+    }
+  }
+}

--- a/wordpress_daily_prayer_time/translations/en.json
+++ b/wordpress_daily_prayer_time/translations/en.json
@@ -1,0 +1,41 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Set up WordPress Daily Prayer Time",
+                "description": "Enter the endpoint URL for prayer time data.",
+                "data": {
+                    "endpoint": "Endpoint URL",
+                    "api_path": "API Path"
+                },
+                "data_description": {
+                    "endpoint": "WordPress Masjid website. e.g., https://masjid-site.com",
+                    "api_path": "API path for full year, usually wp-json/dpt/v1/prayertime?filter=year"
+                },
+                "errors": {
+                    "invalid_url": "Invalid URL. Please provide a valid HTTP or HTTPS URL."
+                }
+            }
+        },
+        "abort": {
+            "already_configured": "WordPress Daily Prayer Time is already configured for this endpoint."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "endpoint": "Endpoint URL",
+                    "api_path": "API Path"
+                },
+                "data_description": {
+                    "endpoint": "WordPress Masjid website. e.g., https://masjid-site.com",
+                    "api_path": "API path for full year, usually wp-json/dpt/v1/prayertime?filter=year"
+                },
+                "errors": {
+                    "invalid_url": "Invalid URL. Please provide a valid HTTP or HTTPS URL."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New WordPress Daily Prayer Time Integration which supports any WordPress-based website with [Daily Prayer Time - Plugin](https://wordpress.org/plugins/daily-prayer-time-for-mosques/) 

NOTE: Islamic Prayer Times -IE  is a deprecated custom component, it is replaced by the wordpress_daily_prayer_time.
